### PR TITLE
Undo stack; offscreen grid cell fetch; URL hash navigation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,56 @@
+# Copilot Instructions for ftw-editing-app
+
+This is a **Vue 3** application built with **Vite**, **TypeScript**, **Vuetify**, and **OpenLayers**. The app focuses on map-based editing of AI model generated polygons of agricultural fields.
+
+## 🏗 Project Architecture
+
+### Map Logic (Critical)
+
+- **Singleton Pattern:** The OpenLayers map instance is a **singleton** managed in `src/composables/useMap.ts`.
+  - **Do not** create new `new Map()` instances in components.
+  - **Always** use `const { map } = useMap()` to access the global map.
+  - The map is configured using `ol-mapbox-style` to load a map configuration from a Mapbox/MapLibre style.
+- **Component Integration:** `src/components/TheMap.vue` is responsible _only_ for providing the DOM target (`map.setTarget()`). It does not manage map state.
+
+### UI & Styling
+
+- **Vuetify 3:** Configured in `src/plugins/vuetify.ts` and imported in `main.ts`.
+- **Styling:**
+  - Avoid inline `style="..."` attributes. Use Vuetify utility classes where possible.
+  - For custom CSS, use **scoped** styles in `<style scoped>` blocks.
+  - Global CSS overrides (e.g. for OpenLayers variables) live in `src/styles.css`.
+- **Icons (Important):** This project uses **SVG paths** (`@mdi/js`), NOT font classes.
+  - **Incorrect:** `<v-icon>mdi-home</v-icon>`
+  - **Correct:**
+    ```vue
+    <script setup lang="ts">
+    import { mdiHome } from '@mdi/js';
+    </script>
+    <template>
+      <v-icon :icon="mdiHome" />
+    </template>
+    ```
+
+## 🛠 Developer Conventions
+
+### Imports & paths
+
+- Use the `@` alias for `src` (e.g., `import { useMap } from '@/composables/map'`).
+- Prefer named imports for Vue compositions and OpenLayers modules to enable tree-shaking.
+
+### TypeScript
+
+- All `.vue` files must use `<script setup lang="ts">`.
+- Use `npm run type-check` (which runs `vue-tsc`) to verify types, as Vite's dev server handles only transpilation.
+
+### Linting
+
+- Run `npm run lint` to fix logic and styling issues.
+- The project follows Prettier formatting rules (via `eslint-config-prettier`).
+
+## 📁 Key Files
+
+- `src/composables/useMap.ts`: Global map instance and layer configuration.
+- `src/components/TheMap.vue`: Main map container component.
+- `src/plugins/vuetify.ts`: Theme and icon configuration.
+- `vite.config.ts`: Build and alias configuration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource/roboto": "^5.2.9",
         "@mdi/js": "^7.4.47",
+        "mgrs": "^2.1.0",
         "ol": "^10.7.0",
         "ol-mapbox-style": "^13.2.0",
         "pmtiles-protocol": "^1.1.2",
@@ -3659,6 +3660,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/mgrs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-2.1.0.tgz",
+      "integrity": "sha512-/pjuM02PUAhp4dazfccTSKBGTGPFkRz9LKwGJKusc/B20apcGG/CYnRHx0kXmLXy4m5O3p6y6nOVxEnErPpFvQ==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@fontsource/roboto": "^5.2.9",
     "@mdi/js": "^7.4.47",
+    "mgrs": "^2.1.0",
     "ol": "^10.7.0",
     "ol-mapbox-style": "^13.2.0",
     "pmtiles-protocol": "^1.1.2",

--- a/src/components/TheWizard.vue
+++ b/src/components/TheWizard.vue
@@ -5,6 +5,7 @@ import {
   mdiDownload,
   mdiDrawPen,
   mdiFileUploadOutline,
+  mdiUndo,
   mdiVectorLine,
   mdiVectorPolygon,
   mdiVectorUnion,
@@ -13,7 +14,7 @@ import { useGrid } from '@/composables/useGrid';
 import { useEdit } from '@/composables/useEdit';
 
 const { gridVisible, selectedGridCellId } = useGrid();
-const { editMode, importGeoJSON, exportGeoJSON } = useEdit();
+const { editMode, importGeoJSON, exportGeoJSON, canUndo, undo } = useEdit();
 
 const panel = ref<string[]>([]);
 const sourceChosen = ref(false);
@@ -25,14 +26,18 @@ watch(
       panel.value = ['edit'];
     } else if (sourceChosen.value) {
       panel.value = ['area-selection'];
-      editMode.value = null;
     } else {
       panel.value = ['source'];
-      editMode.value = null;
     }
   },
   { immediate: true },
 );
+
+watch(panel, (val) => {
+  if (!val.includes('edit')) {
+    editMode.value = null;
+  }
+});
 
 function setMode(mode: 'draw' | 'split' | 'delete' | 'merge') {
   editMode.value = editMode.value === mode ? null : mode;
@@ -143,6 +148,17 @@ function openFilePicker() {
                   :color="editMode === 'merge' ? 'warning' : undefined"
                   :variant="editMode === 'merge' ? 'flat' : 'elevated'"
                   @click="setMode('merge')"
+                />
+              </template>
+            </v-tooltip>
+            <v-tooltip text="Undo" location="bottom">
+              <template v-slot:activator="{ props }">
+                <v-btn
+                  :icon="mdiUndo"
+                  v-bind="props"
+                  :disabled="!canUndo"
+                  variant="elevated"
+                  @click="undo()"
                 />
               </template>
             </v-tooltip>

--- a/src/composables/useGrid.ts
+++ b/src/composables/useGrid.ts
@@ -1,19 +1,31 @@
 import { ref } from 'vue';
 import type VectorTileLayer from 'ol/layer/VectorTile';
+import OlMap from 'ol/Map';
 import type Map from 'ol/Map';
+import View from 'ol/View';
 import type MapBrowserEvent from 'ol/MapBrowserEvent';
-import { setFeatureState } from 'ol-mapbox-style';
+import { MapboxVectorLayer, setFeatureState } from 'ol-mapbox-style';
 import type LayerGroup from 'ol/layer/Group';
+import { Feature as OlFeature } from 'ol';
+import { Polygon } from 'ol/geom';
 import type { FeatureLike } from 'ol/Feature';
 import RenderFeature, { toFeature } from 'ol/render/Feature';
+import { fromLonLat } from 'ol/proj';
+import { inverse } from 'mgrs';
+import { boundingExtent } from 'ol/extent';
+import type { Polygon as GeoJSONPolygon, MultiPolygon as GeoJSONMultiPolygon } from 'geojson';
+import polygonClipping from 'polygon-clipping';
+import GeoJSON from 'ol/format/GeoJSON';
 import { useEdit } from './useEdit';
 
-const { editMode, gridSnapSource, splitAtGridBoundary } = useEdit();
+const { editMode, gridSnapSource } = useEdit();
 
 const gridVisible = ref(false);
 const selectedGridCellId = ref<string | undefined>(undefined);
 
 let grid: VectorTileLayer | undefined;
+let gridMap: Map | undefined;
+let gridMapGroup: LayerGroup | undefined;
 
 const updateGridVisibility = () => {
   if (grid) {
@@ -21,24 +33,152 @@ const updateGridVisibility = () => {
   }
 };
 
-const zoomToFeature = (map: Map, feature: FeatureLike) => {
-  const geometry = feature.getGeometry();
-  if (!geometry) {
-    return;
+/**
+ * Compute the projected extent of a 2×2 km grid cell from its MGRS ID.
+ * Uses simple easting/northing offset to find the NE 1km cell, then
+ * takes the SW corner of the SW cell and NE corner of the NE cell.
+ */
+function gridCellExtent(gridCellId: string) {
+  const mgrs = gridCellId.replace(/^ftw-/, '');
+  const match = mgrs.match(/^(\d{1,2}[A-Z][A-Z]{2})(\d+)$/);
+  if (!match) return undefined;
+  const prefix = match[1]!;
+  const digits = match[2]!;
+  const half = digits.length / 2;
+  const easting = parseInt(digits.slice(0, half), 10);
+  const northing = parseInt(digits.slice(half), 10);
+  const pad = (n: number) => n.toString().padStart(half, '0');
+  const swBbox = inverse(prefix + pad(easting) + pad(northing));
+  const neBbox = inverse(prefix + pad(easting + 1) + pad(northing + 1));
+  const ll: [number, number] = [swBbox[0], swBbox[1]];
+  const ur: [number, number] = [neBbox[2], neBbox[3]];
+  return boundingExtent([fromLonLat(ll), fromLonLat(ur)]);
+}
+
+// ---- Offscreen map for fetching accurate grid cell geometry from PMTiles ----
+
+const format = new GeoJSON();
+
+let offscreenMap: Promise<Map> | undefined;
+let offscreenGrid: Promise<VectorTileLayer> | undefined;
+
+async function getOffscreenGrid(): Promise<VectorTileLayer> {
+  if (!offscreenGrid) {
+    const gridLayer = new MapboxVectorLayer({
+      styleUrl: './style.json',
+      source: 'ftw-grid',
+    });
+    offscreenGrid = new Promise((resolve) => {
+      const source = gridLayer.getSource()!;
+      source.on('change', function unregister() {
+        if (source.getState() !== 'ready') {
+          return;
+        }
+        source.un('change', unregister);
+        resolve(gridLayer);
+      });
+    });
   }
+  return offscreenGrid;
+}
+
+async function getOffscreenMap(): Promise<Map> {
+  if (!offscreenMap) {
+    offscreenMap = new Promise(async (resolve) => {
+      const map = new OlMap({
+        target: document.createElement('div'),
+        layers: [await getOffscreenGrid()],
+        view: new View({ center: [0, 0], zoom: 2 }),
+        controls: [],
+        interactions: [],
+        pixelRatio: 1,
+      });
+      map.setSize([512, 512]);
+      resolve(map);
+    });
+  }
+  return offscreenMap;
+}
+
+/**
+ * Fetch the accurate grid cell polygon from PMTiles using an offscreen map.
+ * Fits view to the computed extent, waits for tiles to render, collects all
+ * features with the given ID (may be split at tile boundaries), and merges
+ * them with polygon-clipping.
+ */
+async function fetchGridCellFeature(gridCellId: string): Promise<OlFeature<Polygon> | undefined> {
+  const extent = gridCellExtent(gridCellId);
+  if (!extent) return undefined;
+
+  const map = await getOffscreenMap();
+  const grid = await getOffscreenGrid();
+
+  // Fit view to grid cell extent
+  map.getView().fit(extent);
+  map.render();
+
+  // Wait for tiles to load
+  await new Promise<void>((resolve) => {
+    map.once('rendercomplete', () => resolve());
+  });
+
+  // Collect all features with the grid cell ID (may be duplicated across tile boundaries)
+  const features = grid.getFeaturesInExtent(extent);
+  const matching = features.filter((f: FeatureLike) => f.get('id') === gridCellId);
+  if (matching.length === 0) return undefined;
+
+  if (matching.length === 1) {
+    return toFeature(matching[0] as RenderFeature) as OlFeature<Polygon>;
+  }
+
+  // Merge fragments with polygon-clipping
+  const projection = map.getView().getProjection();
+  const polys: polygonClipping.MultiPolygon = [];
+  for (const f of matching) {
+    const gj = format.writeFeatureObject(toFeature(f as RenderFeature), {
+      featureProjection: projection,
+    });
+    if (gj.geometry.type === 'Polygon') {
+      polys.push((gj.geometry as GeoJSONPolygon).coordinates as polygonClipping.Polygon);
+    } else if (gj.geometry.type === 'MultiPolygon') {
+      polys.push(
+        ...((gj.geometry as GeoJSONMultiPolygon).coordinates as polygonClipping.MultiPolygon),
+      );
+    }
+  }
+  if (polys.length === 0) return undefined;
+
+  const merged =
+    polys.length === 1 ? [polys[0]!] : polygonClipping.union(polys[0]!, ...polys.slice(1));
+
+  if (merged.length === 0) return undefined;
+  const coords = merged.length === 1 ? merged[0] : merged[0]; // always use first polygon
+  return format.readFeature(
+    { type: 'Feature', geometry: { type: 'Polygon', coordinates: coords } },
+    { featureProjection: projection },
+  ) as OlFeature<Polygon>;
+}
+
+/**
+ * Set the grid snap feature from a grid cell ID.
+ * Fetches the accurate geometry from PMTiles via the offscreen map.
+ */
+async function setGridSnapFeature(gridCellId: string) {
+  gridSnapSource.clear();
+  const feature = await fetchGridCellFeature(gridCellId);
+  if (feature) {
+    gridSnapSource.addFeature(feature);
+  }
+}
+
+function zoomToExtent(map: Map, extent: number[]) {
   const view = map.getView();
   const size = map.getSize();
-  if (!size) {
-    return;
-  }
+  if (!size) return;
   const [width, height] = size;
-  // Padding for 75% viewport usage (12.5% padding on each side)
   const padding = [height! * 0.125, width! * 0.125, height! * 0.125, width! * 0.125];
-  view.fit(geometry.getExtent(), {
-    padding,
-    duration: 500,
-  });
-};
+  view.fit(extent, { padding, duration: 500 });
+}
 
 const selectGridCell = async (event: MapBrowserEvent, mapGroup: LayerGroup) => {
   if (!grid) {
@@ -60,13 +200,14 @@ const selectGridCell = async (event: MapBrowserEvent, mapGroup: LayerGroup) => {
   if (!feature) {
     return;
   }
-  selectedGridCellId.value = feature.get('id');
-  setFeatureState(mapGroup, { source: 'ftw-grid', id: feature.get('id') }, { selected: true });
-  gridSnapSource.clear();
-  const olFeature = toFeature(feature as RenderFeature);
-  gridSnapSource.addFeature(olFeature);
-  splitAtGridBoundary(olFeature);
-  zoomToFeature(map, feature);
+  const id = feature.get('id');
+  selectedGridCellId.value = id;
+  setFeatureState(mapGroup, { source: 'ftw-grid', id }, { selected: true });
+  setGridSnapFeature(id);
+  const extent = gridCellExtent(id);
+  if (extent) {
+    zoomToExtent(map, extent);
+  }
 };
 
 const enableGridCellSelection = (event: MapBrowserEvent) => {
@@ -88,6 +229,8 @@ export function initGrid(
   initialGridCellId?: string,
 ) {
   grid = layer;
+  gridMap = map;
+  gridMapGroup = mapGroup;
   map.on('rendercomplete', updateGridVisibility);
   map.on('singleclick', (event) => {
     if (editMode.value) return;
@@ -97,36 +240,46 @@ export function initGrid(
 
   // Restore grid cell selection from hash
   if (initialGridCellId) {
-    selectGridCellById(initialGridCellId, map, mapGroup);
+    selectGridCellById(initialGridCellId);
   }
 }
 
-function selectGridCellById(id: string, map: Map, mapGroup: LayerGroup) {
+function selectGridCellById(id: string | undefined) {
+  if (!grid || !gridMap || !gridMapGroup) return;
+  const map = gridMap;
+  const mapGroup = gridMapGroup;
+
+  // Deselect current
+  if (selectedGridCellId.value) {
+    setFeatureState(
+      mapGroup,
+      { source: 'ftw-grid', id: selectedGridCellId.value },
+      { selected: null },
+    );
+    gridSnapSource.clear();
+  }
+
+  if (!id) {
+    selectedGridCellId.value = undefined;
+    return;
+  }
+
   // Set the feature state immediately for styling
   setFeatureState(mapGroup, { source: 'ftw-grid', id }, { selected: true });
   selectedGridCellId.value = id;
 
-  // Wait for the grid layer to render, then find the feature for snap/split
-  const findFeature = () => {
-    if (!grid) return;
-    const features = grid.getFeaturesInExtent(map.getView().calculateExtent());
-    const feature = features.find((f) => f.get('id') === id);
-    if (feature) {
-      gridSnapSource.clear();
-      const olFeature = toFeature(feature as RenderFeature);
-      gridSnapSource.addFeature(olFeature);
-      splitAtGridBoundary(olFeature);
-    } else {
-      // Grid tiles may not be loaded yet, retry after next render
-      map.once('rendercomplete', findFeature);
-    }
-  };
-  map.once('rendercomplete', findFeature);
+  // Zoom and set snap/split geometry — all computed from the ID
+  const extent = gridCellExtent(id);
+  if (extent) {
+    zoomToExtent(map, extent);
+  }
+  setGridSnapFeature(id);
 }
 
 export function useGrid() {
   return {
     gridVisible,
     selectedGridCellId,
+    selectGridCellById,
   };
 }

--- a/src/composables/useHash.ts
+++ b/src/composables/useHash.ts
@@ -1,72 +1,52 @@
 import { watch } from 'vue';
-import { toLonLat, fromLonLat } from 'ol/proj';
 import type Map from 'ol/Map';
 import { useGrid } from './useGrid';
 
 let map: Map;
-let updatingHash = false;
+let suppressWatcher = false;
 
-const { selectedGridCellId } = useGrid();
+const { selectedGridCellId, selectGridCellById } = useGrid();
 
-function parseHash(): { center?: [number, number]; zoom?: number; gridCellId?: string } {
+function parseHash(): string | undefined {
   const hash = window.location.hash.replace('#', '');
-  if (!hash) return {};
-  const parts = hash.split('/');
-  const result: { center?: [number, number]; zoom?: number; gridCellId?: string } = {};
-
-  if (parts.length >= 3) {
-    const zoom = parseFloat(parts[0]!);
-    const lat = parseFloat(parts[1]!);
-    const lon = parseFloat(parts[2]!);
-    if (!isNaN(zoom) && !isNaN(lat) && !isNaN(lon)) {
-      result.zoom = zoom;
-      result.center = [lon, lat];
-    }
-  }
-  if (parts.length >= 4 && parts[3]) {
-    result.gridCellId = parts[3];
-  }
-  return result;
+  return hash || undefined;
 }
 
-function updateHash() {
+function pushState() {
+  if (!map || suppressWatcher) return;
+  const gridCellId = selectedGridCellId.value;
+  const hash = gridCellId ? '#' + gridCellId : '#';
+  if (hash !== window.location.hash) {
+    history.pushState(null, '', hash);
+  }
+}
+
+function restoreState(gridCellId: string | undefined) {
   if (!map) return;
-  updatingHash = true;
-  const view = map.getView();
-  const center = view.getCenter();
-  const zoom = view.getZoom();
-  if (!center || zoom === undefined) {
-    updatingHash = false;
-    return;
-  }
-  const [lon, lat] = toLonLat(center);
-  const parts = [zoom.toFixed(2), lat!.toFixed(5), lon!.toFixed(5)];
-  if (selectedGridCellId.value) {
-    parts.push(selectedGridCellId.value);
-  }
-  window.location.hash = parts.join('/');
-  updatingHash = false;
+  if (gridCellId === selectedGridCellId.value) return;
+
+  suppressWatcher = true;
+  selectGridCellById(gridCellId);
+  queueMicrotask(() => {
+    suppressWatcher = false;
+  });
 }
 
 export function initHash(mapInstance: Map) {
   map = mapInstance;
 
-  // Restore view from hash on load
-  const { center, zoom, gridCellId } = parseHash();
-  if (center && zoom !== undefined) {
-    const view = map.getView();
-    view.setCenter(fromLonLat(center));
-    view.setZoom(zoom);
-  }
+  const gridCellId = parseHash();
 
-  // Update hash on map move
-  map.on('moveend', updateHash);
-
-  // Update hash when grid cell selection changes
+  // Push a history entry when grid cell selection changes
   watch(selectedGridCellId, () => {
-    if (!updatingHash) {
-      updateHash();
+    if (!suppressWatcher) {
+      pushState();
     }
+  });
+
+  // Restore state on browser back/forward
+  window.addEventListener('popstate', () => {
+    restoreState(parseHash());
   });
 
   // Return the grid cell ID from the hash for deferred selection


### PR DESCRIPTION
- Add undo/redo stack for all edit operations (draw, modify, split,
  delete, merge, import) with snapshot-based restore
- Fetch accurate grid cell geometry from PMTiles via an offscreen map
  instead of relying on the main map's rendered vector tiles
- Replace thin-polygon split with robust buffer-based difference using
  per-segment rectangle union, with post-split vertex snapping
- Simplify URL hash to grid cell ID only; use history.pushState for
  proper browser back/forward navigation
- Clip features to grid cell boundary only at export time instead of
  eagerly splitting on grid cell selection
- Disable all drawing tools when the edit panel is collapsed
- Compute grid cell zoom extent from MGRS ID using the mgrs package
- Add Copilot instructions for project conventions