### PR TITLE
Deterministic github action cancellation

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: deploy-gh-pages
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v[0-9]*.[0-9]*.[0-9]*'
 
+concurrency:
+  group: deploy-gh-pages
+  cancel-in-progress: true
+
 permissions:
   contents: write
 


### PR DESCRIPTION
To avoid that deploy-prod gets cancelled when a release is published